### PR TITLE
Add support for empty items and for mirrored recipes

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -394,7 +394,7 @@ public class RecipeManager
 			return itemInSlot.isEmpty();
 		}
 
-		// A choice can be null when there's no item in that position. An example of this is minecraft:acacia_boat
+		// A choice can be null when there's no item in that position. An example of this is minecraft:acacia_boat at position "b"
 		@Nullable RecipeChoice choice = ingredientMap.get(recipeChar);
 		if (choice == null)
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -300,6 +300,8 @@ public class RecipeManager
 		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
 		String[] shape = shapedRecipe.getShape();
+		String[] flippedShape = mirrorRecipeHorizontally(shapedRecipe.getShape());
+
 		Map<Character, RecipeChoice> ingredientMap = shapedRecipe.getChoiceMap();
 
 		int recipeHeight = shape.length;
@@ -310,7 +312,14 @@ public class RecipeManager
 		{
 			for (int startCol = 0; startCol <= 3 - recipeWidth; startCol++)
 			{
+				// Validate the recipe
 				if (matchesAtPosition(shape, ingredientMap, craftingMatrix, startRow, startCol))
+				{
+					return true;
+				}
+
+				// Validate the recipe mirrored
+				if (matchesAtPosition(flippedShape, ingredientMap, craftingMatrix, startRow, startCol))
 				{
 					return true;
 				}
@@ -318,6 +327,33 @@ public class RecipeManager
 		}
 
 		return false;
+	}
+
+	/**
+	 * Mirror the recipe in the horizontal axis.
+	 * <p>
+	 * Example: ["abc","def"] will become ["cba", "fed"].
+	 *
+	 * @param shape The recipe to be mirrored.
+	 *
+	 * @return The mirrored recipe.
+	 */
+	private static @NotNull String[] mirrorRecipeHorizontally(@NotNull String[] shape)
+	{
+		String[] flippedShape = shape.clone();
+		if (flippedShape.length > 0)
+		{
+			flippedShape[0] = new StringBuilder(flippedShape[0]).reverse().toString();
+		}
+		if (flippedShape.length > 1)
+		{
+			flippedShape[1] = new StringBuilder(flippedShape[1]).reverse().toString();
+		}
+		if (flippedShape.length > 2)
+		{
+			flippedShape[2] = new StringBuilder(flippedShape[2]).reverse().toString();
+		}
+		return flippedShape;
 	}
 
 	private static boolean matchesAtPosition(String[] shape, Map<Character, RecipeChoice> ingredientMap,
@@ -343,9 +379,10 @@ public class RecipeManager
 		boolean isInRecipe = (row >= startRow && row < startRow + shape.length) &&
 				(col >= startCol && col < startCol + shape[0].length());
 
+		ItemStack itemInSlot = craftingMatrix[index];
 		if (!isInRecipe)
 		{
-			return craftingMatrix[index].isEmpty();
+			return itemInSlot.isEmpty();
 		}
 
 		int recipeRow = row - startRow;
@@ -354,11 +391,19 @@ public class RecipeManager
 
 		if (recipeChar == ' ')
 		{
-			return craftingMatrix[index].isEmpty();
+			return itemInSlot.isEmpty();
 		}
 
-		RecipeChoice choice = ingredientMap.get(recipeChar);
-		return choice != null && choice.test(craftingMatrix[index]);
+		// A choice can be null when there's no item in that position. An example of this is minecraft:acacia_boat
+		@Nullable RecipeChoice choice = ingredientMap.get(recipeChar);
+		if (choice == null)
+		{
+			return itemInSlot.isEmpty();
+		}
+		else
+		{
+			return choice.test(itemInSlot);
+		}
 	}
 
 	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -300,7 +300,7 @@ public class RecipeManager
 		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
 		String[] shape = shapedRecipe.getShape();
-		String[] flippedShape = mirrorRecipeHorizontally(shapedRecipe.getShape());
+		String[] mirroredShape = mirrorRecipeHorizontally(shapedRecipe.getShape());
 
 		Map<Character, RecipeChoice> ingredientMap = shapedRecipe.getChoiceMap();
 
@@ -319,7 +319,7 @@ public class RecipeManager
 				}
 
 				// Validate the recipe mirrored
-				if (matchesAtPosition(flippedShape, ingredientMap, craftingMatrix, startRow, startCol))
+				if (matchesAtPosition(mirroredShape, ingredientMap, craftingMatrix, startRow, startCol))
 				{
 					return true;
 				}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -8,7 +9,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +20,7 @@ import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -410,7 +411,6 @@ class RecipeManagerTest
 			}
 
 			@Test
-			@Disabled("This was not implemented yet")
 			void givenValidCraftMatrix()
 			{
 				ItemStack[] matrix = new ItemStack[]{
@@ -461,6 +461,173 @@ class RecipeManagerTest
 				};
 
 				assertFalse(RecipeManager.matches(newRecipe, invalidMatrix));
+			}
+
+			@Nested
+			class GivenValidSamples
+			{
+
+				@Test
+				void givenSticks()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenSticksWithDifferentMaterials()
+				{
+					ItemStack[] matrix = createCrafting(
+							Material.BIRCH_PLANKS, 	null, 	null,
+							Material.OAK_PLANKS, 			null, 	null,
+							null, 							null, 	null
+					);
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenBoat()
+				{
+					ShapedRecipe boatRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("oak_boat"));
+
+					ItemStack[] matrix = createCrafting(
+							null, 			null, 					null,
+							Material.OAK_PLANKS, 	null, 					Material.OAK_PLANKS,
+							Material.OAK_PLANKS, 	Material.OAK_PLANKS, 	Material.OAK_PLANKS
+					);
+					boolean result = RecipeManager.matches(boatRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenDoor()
+				{
+					ShapedRecipe doorRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("acacia_door"));
+
+					ItemStack[] matrix = createCrafting(
+							null,	Material.ACACIA_PLANKS, Material.ACACIA_PLANKS,
+							null, 			Material.ACACIA_PLANKS, Material.ACACIA_PLANKS,
+							null, 			Material.ACACIA_PLANKS, Material.ACACIA_PLANKS
+					);
+					boolean result = RecipeManager.matches(doorRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenFence()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("acacia_fence"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.ACACIA_PLANKS,	Material.STICK, Material.ACACIA_PLANKS,
+							Material.ACACIA_PLANKS, 		Material.STICK, Material.ACACIA_PLANKS,
+							null, 							null, 			null
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenBow()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("bow"));
+
+					ItemStack[] matrix = createCrafting(
+							null,	Material.STICK, Material.STRING,
+							Material.STICK, null, 			Material.STRING,
+							null, 			Material.STICK, Material.STRING
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenBowFlipped()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("bow"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.STRING,	Material.STICK, null,
+							Material.STRING, 		null, 			Material.STICK,
+							Material.STRING, 		Material.STICK, null
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenStairs()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("stone_stairs"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.STONE,	null, 			null,
+							Material.STONE, 		Material.STONE, null,
+							Material.STONE, 		Material.STONE, Material.STONE
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenStairsFlipped()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("stone_stairs"));
+
+					ItemStack[] matrix = createCrafting(
+							null,		null, 				Material.STONE,
+							null,				Material.STONE, 	Material.STONE,
+							Material.STONE, 	Material.STONE, 	Material.STONE
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				private static ItemStack[] createCrafting(Material... slots)
+				{
+					Preconditions.checkArgument(slots.length == 9, "The crafting table should have 9 items");
+
+					return Stream.of(slots)
+							.map(m -> (m == null ? ItemStack.empty() : ItemStack.of(m)))
+							.toArray(ItemStack[]::new);
+				}
+
+			}
+
+			@Nested
+			class GivenInvalidSamples
+			{
+
+				@Test
+				void givenInvalidStick()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertFalse(result);
+				}
+
+				@Test
+				void givenValidRecipeButWithExtraMaterial()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertFalse(result);
+				}
+
 			}
 
 		}


### PR DESCRIPTION
# Description
Improved worked done in https://github.com/MockBukkit/MockBukkit/pull/1404 by adding support for mirrored recipes and support shaped recipes with empty values like boats.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [X] Unit tests added (if applicable).
